### PR TITLE
Safeguard the base45 decoding

### DIFF
--- a/verify_ehc.py
+++ b/verify_ehc.py
@@ -111,7 +111,10 @@ def decode_ehc(b45_data: str) -> CoseMessage:
         if b45_data.startswith(':'):
             b45_data = b45_data[1:]
 
-    data = b45decode(b45_data)
+    try:
+        data = b45decode(b45_data)
+    except ValueError:
+        raise ValueError(f'Invalid base45 string. Try with single quotes.') from None
 
     if data.startswith(b'x'):
         data = zlib.decompress(data)


### PR DESCRIPTION
It took me longer than I could admit without being ashamed that I needed to use single quotes to decode the base45 string I had. I always had "ValueError" from the base45 module.  
So, I'm proposing a solution that will capture all raised ValueError from base45 decoding, and display a message to hint in the right direction.

I know it might not be the ideal solution. I'm just proposing here :)