### PR TITLE
Add empty user agent to avoid triggering an error 403

### DIFF
--- a/verify_ehc.py
+++ b/verify_ehc.py
@@ -380,7 +380,10 @@ def get_cached_crl(uri: str) -> x509.CertificateRevocationList:
     if status_code is not None:
         raise ValueError(f'{status_code} {http.client.responses.get(status_code, "")}')
 
-    response = requests.get(uri)
+    headers = {
+        'User-Agent': ''
+    }
+    response = requests.get(uri, headers=headers)
     status_code = response.status_code
     crl_status[uri] = status_code
 


### PR DESCRIPTION
When trying the script with my own data, it went to download the CRL from the ANTS, at http://ants.gouv.fr/csca_crl, and it triggered an error 403, Forbidden.

Adding an user-agent, even empty, solved the issue for me.

 Since it's a simple fix, I'm proposing it. It could backfire, depending on the settings of others servers, but I doubt it.