### PR TITLE
Read QR Codes from PDF Files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ jwcrypto
 python-dateutil
 lxml
 asn1crypto
+pdf2image

--- a/verify_ehc.py
+++ b/verify_ehc.py
@@ -2301,14 +2301,23 @@ def main() -> None:
     if args.image:
         from pyzbar.pyzbar import decode as decode_qrcode # type: ignore
         from PIL import Image # type: ignore
+        from pdf2image import convert_from_path
 
         for filename in args.ehc_code:
-            image = Image.open(filename, 'r')
-            qrcodes = decode_qrcode(image)
-            if qrcodes:
-                for qrcode in qrcodes:
-                    ehc_codes.append(qrcode.data.decode("utf-8"))
+            images: List[Image] = []
+            if filename.endswith('.pdf'):
+                images = convert_from_path(filename)
             else:
+                images.append(Image.open(filename, 'r'))
+
+            if images:
+                for image in images:
+                    qrcodes = decode_qrcode(image)
+                    if qrcodes:
+                        for qrcode in qrcodes:
+                            ehc_codes.append(qrcode.data.decode("utf-8"))
+
+            if not ehc_codes:
                 print_err(f'{filename}: no qr-code found')
     else:
         ehc_codes.extend(args.ehc_code)


### PR DESCRIPTION
Some countries, e.g. Switzerland, offer direct export from the COVID app to PDF. 

To avoid first converting PDFs to images, I implemented this step into the code. 

It supports multiple pages, in case you combined a series of certificates to one bundle. 